### PR TITLE
Integrate omni menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,178 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Owl is a modular dotfiles and environment management CLI written in Rust. It manages configurations across different machines through:
+- **Setups**: Modular units that handle software configuration (in `setups/`)
+- **Nests**: Machine-specific environments that bundle setups together (in `nests/`)
+- **Common**: Shared configurations and scripts (in `common/`)
+
+## Development Commands
+
+### Building and Running
+```bash
+cargo build                    # Build the project
+cargo run -- <args>           # Run with arguments
+cargo build --release         # Production build
+
+# Example: Test nest linking
+cargo run -- nest link
+cargo run -- setup git info
+```
+
+### Testing Changes
+```bash
+# Install the built binary
+cargo build && cargo run -- nest link
+
+# The binary is linked to ~/.local/bin/owl via nest link
+# After linking, you can use `owl` directly
+```
+
+### Validation
+```bash
+owl setups-validate           # Validate all setup.json files
+```
+
+## Architecture
+
+### Core Data Model
+
+The codebase follows a **validate-first pattern**:
+
+1. **SetupFile** (`setup.json`): Raw JSON with all optional fields
+   - Parsed directly from disk using serde
+   - All fields are `Option<T>` to handle missing values
+
+2. **Setup**: Validated, resolved in-memory representation
+   - Created by validating a `SetupFile`
+   - All paths are resolved (no more `local:` or `common:` tokens)
+   - Used for all operations (link, install, systemd)
+
+3. **Validated types**: Specific structs for each component
+   - `ValidatedSetupLink`: Resolved source/target paths with root flag
+   - `ValidatedRunScript`: RC scripts with resolved paths
+   - `ValidatedSetupMenuScriptItem`: Menu scripts with paths and names
+   - `ValidatedSetupService`: Services with resolved unit files and types
+
+### Path Resolution
+
+The system uses path tokens that are resolved during validation:
+
+- `local:<path>` → Relative to the setup directory (e.g., `setups/<name>/...`)
+- `common:<path>` → Relative to `common/` in the repo root
+- `~` → Expands to user home directory
+- Absolute paths pass through as-is
+
+Example:
+```json
+{
+  "source": "local:config/sway.conf",      // → setups/sway/config/sway.conf
+  "source": "common:config/.vimrc",        // → common/config/.vimrc
+  "source": "~/custom/.zshrc"              // → /home/user/custom/.zshrc
+}
+```
+
+### Setup System
+
+**setup.json schema** (all fields optional):
+```json
+{
+  "name": "git",
+  "dependencies": ["base-shell"],
+  "install": "local:install.sh",
+  "links": [
+    {
+      "source": "local:gitconfig",
+      "target": "~/.gitconfig",
+      "root": false
+    }
+  ],
+  "rc_scripts": ["common:git-aliases.sh", "local:rc.sh"],
+  "menu_scripts": ["local:menu-helper.sh"],
+  "services": [
+    {
+      "path": "local:my-service.service",
+      "service_type": "User"
+    }
+  ]
+}
+```
+
+**Key concepts:**
+- **dependencies**: Other setups to install first (recursive)
+- **links**: Files/directories to symlink to target locations
+- **rc_scripts**: Shell scripts sourced at startup (linked to `~/.config/owl/rc/`)
+- **menu_scripts**: Scripts for dmenu/rofi (linked to `~/.config/owl/menu-scripts/`)
+- **services**: Systemd units to link and enable (User or System scope)
+
+### Nest System
+
+Nests are root setups in `nests/` that define complete machine environments. They use the same `setup.json` format but typically:
+- Declare many dependencies
+- Include machine-specific links and rc_scripts
+- Use `local:` paths relative to the nest directory
+
+The active nest is tracked in `~/.config/owl/config.json` as `nest_path`.
+
+### CLI Structure
+
+Entry point: `src/main.rs`
+
+Main command groups:
+- **setup**: Operations on individual setups
+  - `owl setup <name> link|install|systemd|info|edit|all [--shallow]`
+- **nest**: Operations on the active nest (shorthand for root setup)
+  - `owl nest link|install|systemd|info|edit|switch|all [--shallow]`
+- **system**: Configuration and maintenance
+  - `owl config`: Show current config
+  - `owl sync`: Sync repository (fetch, fast-forward, optional push)
+  - `owl update [--recursive]`: Update owl binary
+  - `owl setups-validate`: Validate all setups
+
+The `--shallow` flag prevents recursive dependency processing.
+
+## Code Conventions
+
+### Rust Patterns
+- Keep all `setup.json` fields optional - validation happens separately
+- Use free functions over large impls for CLI orchestration
+- Fail fast at validation time with clear, user-friendly errors
+- Print structured progress with emojis and colors during operations
+- Remove dead code; prefer `quiet: bool` parameters over duplicate functions
+
+### Shell Scripts
+- Use `set -euo pipefail` unless interactive
+- Quote variable expansions: `"${VAR}"`
+- Make install scripts idempotent (check before installing)
+- Scripts receive resolved absolute paths (no `local:` or `common:` tokens)
+
+### Path Resolution
+- Use the single unified resolver for all path token expansion
+- All validated types store resolved `PathBuf`s
+- Never operate on raw string paths from JSON
+
+## Common Setup Patterns
+
+### Adding a new setup
+1. Create `setups/<name>/setup.json`
+2. Add configuration files to the setup directory
+3. Use `local:` for files in the setup, `common:` for shared files
+4. Define dependencies on other setups if needed
+5. Run `owl setups-validate` to check correctness
+
+### Adding to a nest
+Edit `nests/<machine>/setup.json` and add the setup name to `dependencies`.
+
+### Service management
+Services are linked during `link` and enabled/started during `systemd`:
+- User services → `~/.config/systemd/user/`
+- System services → `/etc/systemd/system/` (requires sudo)
+
+### Debugging
+- Use `owl setup <name> info` to see what would be linked
+- Check `~/.config/owl/config.json` for active configuration
+- RC scripts are in `~/.config/owl/rc/` as `rc-<setup>-<filename>`
+- Menu scripts are in `~/.config/owl/menu-scripts/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,3 +176,59 @@ Services are linked during `link` and enabled/started during `systemd`:
 - Check `~/.config/owl/config.json` for active configuration
 - RC scripts are in `~/.config/owl/rc/` as `rc-<setup>-<filename>`
 - Menu scripts are in `~/.config/owl/menu-scripts/`
+
+## Omni-Menu
+
+Omni-menu is a GTK4-based application launcher integrated into owl as a second binary. It provides a unified interface for common desktop tasks.
+
+### Architecture
+
+**Location**: `src/omni_menu/`
+
+**Binary**: Built as `omni-menu` alongside the `owl` binary in Cargo.toml
+
+**Modules**:
+- `main.rs` - Entry point with subcommand routing
+- `main_menu.rs` - Main menu UI with keyboard shortcuts
+- `search_menu.rs` - Web search (Google, ChatGPT, Notes)
+- `projects_menu.rs` - Local/remote dev project launcher
+- `scripts_menu.rs` - Owl scripts menu
+- `launch_tool_menu.rs` - Launch tools in current workspace
+- `switch_bench_menu.rs` - Yard bench switcher
+- `desk_menu.rs` - Owl desk configuration switcher
+- `emoji_menu.rs` - Emoji picker (rofi wrapper)
+- `utils.rs` - Shared utilities for list population and filtering
+
+### Usage
+
+```bash
+omni-menu              # Main menu (default)
+omni-menu search       # Web search
+omni-menu projects     # Project launcher
+omni-menu scripts      # Owl scripts
+omni-menu launch_tool  # Launch tools
+omni-menu switch_bench # Switch yard bench
+omni-menu desk         # Switch desk configuration
+omni-menu emoji        # Pick emoji
+```
+
+### Integration with Owl
+
+- **Desk Integration**: Detects Sway/i3 via `SWAYSOCK` env var, lists desk scripts from `~/.config/desks-sway/` or `~/.config/desks-i3/`
+- **Scripts Integration**: Reads from owl's menu scripts directory
+- **Setup**: Linked via `setups/menu/setup.json` to `~/.local/bin/omni-menu`
+
+### Building
+
+```bash
+cargo build --bin omni-menu    # Build omni-menu binary
+cargo build                     # Build both owl and omni-menu
+owl setup menu link             # Link binary to ~/.local/bin
+```
+
+### Design Patterns
+
+- Each menu module is self-contained with its own GTK4 application
+- Modules follow the `pub mod <name> { pub fn run_app() -> glib::ExitCode }` pattern
+- Main menu spawns submenus by re-invoking itself with different arguments
+- Utilities module provides shared list filtering and fuzzy matching functionality

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,14 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "owl"
+path = "src/main.rs"
+
+[[bin]]
+name = "omni-menu"
+path = "src/omni_menu/main.rs"
+
 [dependencies]
 clap = { version = "4.3.21", features = ["derive"] }
 colored = "2.0.4"
@@ -13,3 +21,7 @@ serde_json = "1.0.105"
 shellexpand = "3.1.0"
 thiserror = "1.0"
 once_cell = "1.19"
+gtk = { version = "0.10.2", package = "gtk4" }
+fuzzy-matcher = "0.3"
+dirs = "5.0"
+regex = "1.5"

--- a/nests/framework-sway/bg-picker.sh
+++ b/nests/framework-sway/bg-picker.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get wallpaper directory from environment or use default
+WALL_DIR="${WALL_DIR:-$HOME/docs/media/wallpapers}"
+
+if [ ! -d "$WALL_DIR" ]; then
+    echo "Wallpaper directory not found: $WALL_DIR"
+    exit 1
+fi
+
+# Find all image files and show in rofi with just the filename
+selected=$(find "$WALL_DIR" -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \) -printf "%f\n" | sort | rofi -dmenu -i -p "Select Background")
+
+if [ -n "$selected" ]; then
+    # Find the full path of the selected file
+    full_path=$(find "$WALL_DIR" -type f -name "$selected" | head -1)
+
+    if [ -n "$full_path" ]; then
+        # Set wallpaper using swww
+        swww img "$full_path" --transition-type fade --transition-duration 1
+    fi
+fi

--- a/nests/framework-sway/setup.json
+++ b/nests/framework-sway/setup.json
@@ -1,4 +1,5 @@
 {
+    "name": "framework-sway",
     "dependencies": [
         "git",
         "bun",
@@ -35,18 +36,14 @@
     ],
     "menu_scripts": [
         {
-            "name": "Emoji",
-            "path": "common:emoji.sh"
-        },
-        {
-            "name": "Run Script",
-            "path": "common:run-script.sh"
+            "name": "Background Picker",
+            "path": "local:bg-picker.sh"
         }
     ],
-    "name": "framework-sway",
     "rc_scripts": [
         "common:fzf.sh",
         "common:base-aliases.sh",
         "common:systemctl-aliases.sh"
-    ]
+    ],
+    "only_own_menu_scripts": true
 }

--- a/setups/i3/i3-config
+++ b/setups/i3/i3-config
@@ -19,8 +19,8 @@ for_window [title="ClipGPT"] floating enable
 for_window [class="Spotify"] move to workspace 9
 
 # Rofi
-bindsym $mod+i exec "~/.local/bin/omni-menu run"
-bindsym $mod+o exec "~/.local/bin/omni-menu window"
+bindsym $mod+i exec "~/.local/bin/omni-menu launch_tool"
+bindsym $mod+o exec "rofi -show window"
 bindsym $mod+p exec "~/.local/bin/omni-menu"
 bindsym $mod+n exec $TERMINAL --role floating -e "tt notes tui"
 

--- a/setups/kitty/kitty.conf
+++ b/setups/kitty/kitty.conf
@@ -34,3 +34,4 @@ color15  #FFFFFF
 
 # Optional padding
 window_padding_width 6.0
+map shift+enter send_text all \e\r

--- a/setups/menu/install.sh
+++ b/setups/menu/install.sh
@@ -1,5 +1,0 @@
-git clone git@github.com:tylerthecoder/omni-menu.git ~/dev/omni-menu
-
-cd ~/dev/omni-menu
-
-make install

--- a/setups/menu/setup.json
+++ b/setups/menu/setup.json
@@ -2,7 +2,7 @@
   "name": "menu",
   "links": [
     {
-      "source": "target/debug/omni-menu",
+      "source": "target/release/omni-menu",
       "target": "~/.local/bin/omni-menu"
     }
   ]

--- a/setups/menu/setup.json
+++ b/setups/menu/setup.json
@@ -1,5 +1,9 @@
 {
-  "install": "local:install.sh",
   "name": "menu",
-  "links": []
+  "links": [
+    {
+      "source": "target/debug/omni-menu",
+      "target": "~/.local/bin/omni-menu"
+    }
+  ]
 }

--- a/setups/sway/scripts/desks/framework-sway.sh
+++ b/setups/sway/scripts/desks/framework-sway.sh
@@ -9,10 +9,10 @@ for out in $(swaymsg -t get_outputs | jq -r '.[].name'); do
   fi
 done
 
-swaymsg output eDP-1 enable mode 2880x1920 position 0 0 scale 1.4
+swaymsg output eDP-1 enable mode 2880x1920 position 0 0 scale 1.5
 
 # Key repeat and caps as super in Wayland
-swaymsg input type:keyboard repeat_delay 200
-swaymsg input type:keyboard repeat_rate 40
+swaymsg input type:keyboard repeat_delay 300
+swaymsg input type:keyboard repeat_rate 25
 swaymsg input type:keyboard xkb_options caps:super
 

--- a/setups/sway/scripts/desks/framework-sway.sh
+++ b/setups/sway/scripts/desks/framework-sway.sh
@@ -9,7 +9,7 @@ for out in $(swaymsg -t get_outputs | jq -r '.[].name'); do
   fi
 done
 
-swaymsg output eDP-1 enable mode 2880x1920 position 0 0
+swaymsg output eDP-1 enable mode 2880x1920 position 0 0 scale 1.4
 
 # Key repeat and caps as super in Wayland
 swaymsg input type:keyboard repeat_delay 200

--- a/src/omni_menu/desk_menu.rs
+++ b/src/omni_menu/desk_menu.rs
@@ -1,0 +1,169 @@
+pub mod desk_menu {
+    use gtk::prelude::*;
+    use gtk::{
+        glib, Application, ApplicationWindow, Box as GtkBox, Entry, Label, ListBox,
+        Orientation, ScrolledWindow,
+    };
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use crate::utils::{populate_list, filter_list};
+
+    const APP_ID: &str = "org.gtk_rs.DeskMenu";
+
+    fn get_desks_dir() -> PathBuf {
+        let home = dirs::home_dir().unwrap();
+        // Check if we're in Sway or i3
+        if std::env::var("SWAYSOCK").is_ok() {
+            home.join(".config/desks-sway")
+        } else {
+            home.join(".config/desks-i3")
+        }
+    }
+
+    fn get_desk_scripts() -> Vec<String> {
+        let desks_dir = get_desks_dir();
+        if !desks_dir.exists() {
+            return Vec::new();
+        }
+
+        match fs::read_dir(&desks_dir) {
+            Ok(entries) => entries
+                .filter_map(|entry| {
+                    let entry = entry.ok()?;
+                    let file_name = entry.file_name().to_str()?.to_string();
+                    // Only include executable files or .sh files
+                    if file_name.ends_with(".sh") || entry.metadata().ok()?.permissions().mode() & 0o111 != 0 {
+                        Some(file_name)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn build_ui(app: &Application) {
+        let window = ApplicationWindow::builder()
+            .application(app)
+            .title("Select Desk")
+            .default_width(500)
+            .default_height(600)
+            .decorated(true)
+            .resizable(false)
+            .modal(true)
+            .build();
+
+        let vbox = GtkBox::new(Orientation::Vertical, 5);
+        vbox.set_margin_top(10);
+        vbox.set_margin_bottom(10);
+        vbox.set_margin_start(10);
+        vbox.set_margin_end(10);
+
+        // Search entry
+        let search_entry = Entry::new();
+        search_entry.set_placeholder_text(Some("Type to filter desks..."));
+        vbox.append(&search_entry);
+
+        // Scrolled window
+        let scrolled_window = ScrolledWindow::builder()
+            .hscrollbar_policy(gtk::PolicyType::Never)
+            .vscrollbar_policy(gtk::PolicyType::Automatic)
+            .vexpand(true)
+            .build();
+
+        let list_box = ListBox::new();
+        list_box.set_selection_mode(gtk::SelectionMode::Single);
+        list_box.set_activate_on_single_click(true);
+        scrolled_window.set_child(Some(&list_box));
+
+        vbox.append(&scrolled_window);
+        window.set_child(Some(&vbox));
+
+        // Get desks and populate
+        let desks = get_desk_scripts();
+        if desks.is_empty() {
+            let label = Label::new(Some("No desk scripts found"));
+            label.set_margin_top(20);
+            list_box.append(&gtk::ListBoxRow::new());
+            let row = list_box.row_at_index(0).unwrap();
+            row.set_child(Some(&label));
+        } else {
+            populate_list(&list_box, &desks);
+        }
+
+        // Handle search
+        let list_box_weak = list_box.downgrade();
+        let desks_clone = desks.clone();
+        search_entry.connect_changed(move |entry| {
+            if let Some(list_box) = list_box_weak.upgrade() {
+                let query = entry.text().to_string().to_lowercase();
+                filter_list(&list_box, &desks_clone, &query);
+            }
+        });
+
+        // Handle activation
+        let window_weak = window.downgrade();
+        let desks_dir = get_desks_dir();
+        list_box.connect_row_activated(move |_, row| {
+            if let Some(label) = row.child().and_then(|w| w.downcast::<Label>().ok()) {
+                let desk_name = label.text().to_string();
+                let desk_path = desks_dir.join(&desk_name);
+
+                // Execute the desk script
+                Command::new(&desk_path)
+                    .spawn()
+                    .ok();
+
+                if let Some(window) = window_weak.upgrade() {
+                    window.close();
+                }
+            }
+        });
+
+        // Handle Enter key on search entry
+        let list_box_weak = list_box.downgrade();
+        search_entry.connect_activate(move |_| {
+            if let Some(list_box) = list_box_weak.upgrade() {
+                if let Some(first_row) = list_box.first_child() {
+                    let row_count = list_box.observe_children().n_items();
+                    if row_count == 1 {
+                        list_box.emit_by_name::<()>(
+                            "row-activated",
+                            &[&first_row.downcast_ref::<gtk::ListBoxRow>().unwrap()],
+                        );
+                    } else if row_count > 1 {
+                        list_box.select_row(Some(first_row.downcast_ref::<gtk::ListBoxRow>().unwrap()));
+                        list_box.grab_focus();
+                    }
+                }
+            }
+        });
+
+        // Handle Escape key
+        let key_controller = gtk::EventControllerKey::new();
+        let window_weak_key = window.downgrade();
+        key_controller.connect_key_pressed(move |_, key, _, _| {
+            if key == gtk::gdk::Key::Escape {
+                if let Some(window) = window_weak_key.upgrade() {
+                    window.close();
+                }
+                return glib::Propagation::Stop;
+            }
+            glib::Propagation::Proceed
+        });
+        window.add_controller(key_controller);
+
+        search_entry.grab_focus();
+        window.present();
+    }
+
+    pub fn run_app() -> glib::ExitCode {
+        let app = Application::builder().application_id(APP_ID).build();
+        app.connect_activate(build_ui);
+        let no_args: [&str; 0] = [];
+        app.run_with_args(&no_args)
+    }
+}

--- a/src/omni_menu/emoji_menu.rs
+++ b/src/omni_menu/emoji_menu.rs
@@ -1,0 +1,18 @@
+pub mod emoji_menu {
+    use gtk::glib;
+    use std::process::Command;
+
+    pub fn run_app() -> glib::ExitCode {
+        // Simply launch rofi in emoji mode
+        match Command::new("rofi")
+            .args(["-modi", "emoji", "-show", "emoji"])
+            .spawn()
+        {
+            Ok(_) => glib::ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("Failed to launch rofi emoji picker: {}", e);
+                glib::ExitCode::FAILURE
+            }
+        }
+    }
+}

--- a/src/omni_menu/launch_tool_menu.rs
+++ b/src/omni_menu/launch_tool_menu.rs
@@ -1,0 +1,126 @@
+pub mod launch_tool_menu {
+    use crate::utils::{filter_list, populate_list};
+    use gtk::prelude::*;
+    use gtk::{
+        glib, Application, ApplicationWindow, Box as GtkBox, Entry, Label, ListBox, Orientation,
+        ScrolledWindow,
+    };
+    use std::process::Command;
+
+    const APP_ID: &str = "org.gtk_rs.LaunchToolMenu";
+
+    fn build_ui(app: &Application) {
+        let window = ApplicationWindow::builder()
+            .application(app)
+            .title("Launch Tool")
+            .default_width(500)
+            .default_height(600)
+            .decorated(true)
+            .resizable(false)
+            .modal(true)
+            .build();
+
+        let vbox = GtkBox::new(Orientation::Vertical, 5);
+        vbox.set_margin_top(10);
+        vbox.set_margin_bottom(10);
+        vbox.set_margin_start(10);
+        vbox.set_margin_end(10);
+
+        // Search entry
+        let search_entry = Entry::new();
+        search_entry.set_placeholder_text(Some("Type to filter tools..."));
+        vbox.append(&search_entry);
+
+        // Scrolled window for list items
+        let scrolled_window = ScrolledWindow::builder()
+            .hscrollbar_policy(gtk::PolicyType::Never)
+            .vscrollbar_policy(gtk::PolicyType::Automatic)
+            .vexpand(true)
+            .build();
+
+        let list_box = ListBox::new();
+        list_box.set_selection_mode(gtk::SelectionMode::Single);
+        list_box.set_activate_on_single_click(true);
+        scrolled_window.set_child(Some(&list_box));
+
+        vbox.append(&scrolled_window);
+        window.set_child(Some(&vbox));
+
+        // Get tools and populate
+        let tools = get_yard_tools();
+        populate_list(&list_box, &tools);
+
+        // Handle search
+        let list_box_weak = list_box.downgrade();
+        let tools_clone = tools.clone();
+        search_entry.connect_changed(move |entry| {
+            if let Some(list_box) = list_box_weak.upgrade() {
+                let query = entry.text().to_string().to_lowercase();
+                filter_list(&list_box, &tools_clone, &query);
+            }
+        });
+
+        // Handle activation
+        let window_weak = window.downgrade();
+        list_box.connect_row_activated(move |_, row| {
+            if let Some(label) = row.child().and_then(|w| w.downcast::<Label>().ok()) {
+                let tool_name = label.text().to_string();
+                // Call yard to assemble the tool
+                Command::new("yard")
+                    .args(["tool", "assemble", &tool_name])
+                    .spawn()
+                    .ok();
+
+                if let Some(window) = window_weak.upgrade() {
+                    window.close();
+                }
+            }
+        });
+
+        // Handle Escape key
+        let key_controller = gtk::EventControllerKey::new();
+        let window_weak_key = window.downgrade();
+        key_controller.connect_key_pressed(move |_, key, _, _| {
+            if key == gtk::gdk::Key::Escape {
+                if let Some(window) = window_weak_key.upgrade() {
+                    window.close();
+                }
+                return glib::Propagation::Stop;
+            }
+            glib::Propagation::Proceed
+        });
+        window.add_controller(key_controller);
+
+        search_entry.grab_focus();
+        window.present();
+    }
+
+    fn get_yard_tools() -> Vec<String> {
+        println!("Running: yard tool list");
+        let output = Command::new("yard").args(["tool", "list"]).output();
+
+        match output {
+            Ok(o) => {
+                let stdout = String::from_utf8_lossy(&o.stdout);
+                // Simple parsing: one tool per line
+                stdout
+                    .lines()
+                    .map(|line| line.trim())
+                    .filter(|line| !line.is_empty())
+                    .map(|s| s.to_string())
+                    .collect()
+            }
+            Err(e) => {
+                println!("Error running yard: {}", e);
+                Vec::new()
+            }
+        }
+    }
+
+    pub fn run_app() -> glib::ExitCode {
+        let app = Application::builder().application_id(APP_ID).build();
+        app.connect_activate(build_ui);
+        let no_args: [&str; 0] = [];
+        app.run_with_args(&no_args)
+    }
+}

--- a/src/omni_menu/main.rs
+++ b/src/omni_menu/main.rs
@@ -1,6 +1,8 @@
 use gtk::glib;
 use std::env;
 
+mod desk_menu;
+mod emoji_menu;
 mod launch_tool_menu;
 mod main_menu;
 mod projects_menu;
@@ -20,9 +22,11 @@ fn main() -> glib::ExitCode {
             "launch_tool" => launch_tool_menu::launch_tool_menu::run_app(),
             "switch_bench" => switch_bench_menu::switch_bench_menu::run_app(),
             "scripts" => scripts_menu::scripts_menu::run_app(),
+            "desk" => desk_menu::desk_menu::run_app(),
+            "emoji" => emoji_menu::emoji_menu::run_app(),
             _ => {
                 eprintln!(
-                    "Usage: rust-menu [main|search|projects|launch_tool|switch_bench|scripts]"
+                    "Usage: omni-menu [main|search|projects|launch_tool|switch_bench|scripts|desk|emoji]"
                 );
                 glib::ExitCode::FAILURE
             }

--- a/src/omni_menu/main.rs
+++ b/src/omni_menu/main.rs
@@ -1,0 +1,34 @@
+use gtk::glib;
+use std::env;
+
+mod launch_tool_menu;
+mod main_menu;
+mod projects_menu;
+mod scripts_menu;
+mod search_menu;
+mod switch_bench_menu;
+mod utils;
+
+fn main() -> glib::ExitCode {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() > 1 {
+        match args[1].as_str() {
+            "main" => main_menu::main_menu::run_app(),
+            "search" => search_menu::search_menu::run_app(),
+            "projects" => projects_menu::projects_menu::run_app(),
+            "launch_tool" => launch_tool_menu::launch_tool_menu::run_app(),
+            "switch_bench" => switch_bench_menu::switch_bench_menu::run_app(),
+            "scripts" => scripts_menu::scripts_menu::run_app(),
+            _ => {
+                eprintln!(
+                    "Usage: rust-menu [main|search|projects|launch_tool|switch_bench|scripts]"
+                );
+                glib::ExitCode::FAILURE
+            }
+        }
+    } else {
+        // Default to main menu
+        main_menu::main_menu::run_app()
+    }
+}

--- a/src/omni_menu/main_menu.rs
+++ b/src/omni_menu/main_menu.rs
@@ -1,0 +1,129 @@
+pub mod main_menu {
+    use gtk::prelude::*;
+    use gtk::{glib, Application, ApplicationWindow, Box as GtkBox, Label, Orientation};
+    use std::process::Command;
+
+    const APP_ID: &str = "org.gtk_rs.OmniMenu";
+
+    fn build_ui(app: &Application) {
+        let window = ApplicationWindow::builder()
+            .application(app)
+            .title("Omni Menu")
+            .default_width(500)
+            .default_height(400)
+            .decorated(true)
+            .resizable(false)
+            .modal(true)
+            .build();
+
+        let vbox = GtkBox::new(Orientation::Vertical, 5);
+        vbox.set_margin_top(10);
+        vbox.set_margin_bottom(10);
+        vbox.set_margin_start(10);
+        vbox.set_margin_end(10);
+
+        // Title label
+        let title_label = Label::new(Some("Main Menu"));
+        title_label.set_markup("<span size='large' weight='bold'>Main Menu</span>");
+        title_label.set_halign(gtk::Align::Start);
+        vbox.append(&title_label);
+
+        // Instructions label
+        let instructions_label = Label::new(Some("Press a hotkey to open a submenu"));
+        instructions_label.set_halign(gtk::Align::Start);
+        instructions_label.set_margin_top(10);
+        vbox.append(&instructions_label);
+
+        // Menu options box
+        let menu_box = GtkBox::new(Orientation::Vertical, 5);
+        menu_box.set_margin_top(10);
+
+        let options = vec![
+            ("(t) Launch Tool", "Add a tool to the current workspace"),
+            ("(a) Launch App", "Launch any application"),
+            ("(b) Switch Bench", "Switch to a different bench"),
+            ("(s) Scripts", "Run owl scripts"),
+            ("(x) Search", "Search the web"),
+        ];
+
+        for (option, description) in options {
+            let option_box = GtkBox::new(Orientation::Vertical, 2);
+
+            let option_label = Label::new(Some(option));
+            option_label.set_markup(&format!("<b>{}</b>", option));
+            option_label.set_halign(gtk::Align::Start);
+            option_box.append(&option_label);
+
+            let desc_label = Label::new(Some(description));
+            desc_label.set_halign(gtk::Align::Start);
+            desc_label.add_css_class("dim-label");
+            desc_label.set_margin_start(20);
+            option_box.append(&desc_label);
+
+            menu_box.append(&option_box);
+        }
+
+        vbox.append(&menu_box);
+        window.set_child(Some(&vbox));
+
+        // Set up keyboard handler
+        let key_controller = gtk::EventControllerKey::new();
+        let window_weak = window.downgrade();
+
+        key_controller.connect_key_pressed(move |_, key, _, _| {
+            let window = match window_weak.upgrade() {
+                Some(w) => w,
+                None => return glib::Propagation::Proceed,
+            };
+
+            // Handle Escape
+            if key == gtk::gdk::Key::Escape {
+                window.close();
+                return glib::Propagation::Stop;
+            }
+
+            let exe = std::env::current_exe().unwrap_or_else(|_| "rust-menu".into());
+
+            match key {
+                gtk::gdk::Key::t => {
+                    Command::new(&exe).arg("launch_tool").spawn().ok();
+                    window.close();
+                    return glib::Propagation::Stop;
+                }
+                gtk::gdk::Key::a => {
+                    Command::new("rofi").args(["-show", "drun"]).spawn().ok();
+                    window.close();
+                    return glib::Propagation::Stop;
+                }
+                gtk::gdk::Key::b => {
+                    Command::new(&exe).arg("switch_bench").spawn().ok();
+                    window.close();
+                    return glib::Propagation::Stop;
+                }
+                gtk::gdk::Key::s => {
+                    Command::new(&exe).arg("scripts").spawn().ok();
+                    window.close();
+                    return glib::Propagation::Stop;
+                }
+                gtk::gdk::Key::x => {
+                    Command::new(&exe).arg("search").spawn().ok();
+                    window.close();
+                    return glib::Propagation::Stop;
+                }
+                _ => {}
+            }
+
+            glib::Propagation::Proceed
+        });
+
+        window.add_controller(key_controller);
+        window.present();
+    }
+
+    pub fn run_app() -> glib::ExitCode {
+        let app = Application::builder().application_id(APP_ID).build();
+        app.connect_activate(build_ui);
+        let no_args: [&str; 0] = [];
+        app.run_with_args(&no_args)
+    }
+}

--- a/src/omni_menu/main_menu.rs
+++ b/src/omni_menu/main_menu.rs
@@ -42,6 +42,8 @@ pub mod main_menu {
             ("(t) Launch Tool", "Add a tool to the current workspace"),
             ("(a) Launch App", "Launch any application"),
             ("(b) Switch Bench", "Switch to a different bench"),
+            ("(d) Desk", "Switch to a different desk configuration"),
+            ("(e) Emoji", "Pick an emoji to copy"),
             ("(s) Scripts", "Run owl scripts"),
             ("(x) Search", "Search the web"),
         ];
@@ -97,6 +99,16 @@ pub mod main_menu {
                 }
                 gtk::gdk::Key::b => {
                     Command::new(&exe).arg("switch_bench").spawn().ok();
+                    window.close();
+                    return glib::Propagation::Stop;
+                }
+                gtk::gdk::Key::d => {
+                    Command::new(&exe).arg("desk").spawn().ok();
+                    window.close();
+                    return glib::Propagation::Stop;
+                }
+                gtk::gdk::Key::e => {
+                    Command::new(&exe).arg("emoji").spawn().ok();
                     window.close();
                     return glib::Propagation::Stop;
                 }

--- a/src/omni_menu/projects_menu.rs
+++ b/src/omni_menu/projects_menu.rs
@@ -1,0 +1,433 @@
+pub mod projects_menu {
+    use fuzzy_matcher::skim::SkimMatcherV2;
+    use fuzzy_matcher::FuzzyMatcher;
+    use gtk::prelude::*;
+    use gtk::{glib, Application, ApplicationWindow, Entry, ListBox, ScrolledWindow};
+    use regex::Regex;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::rc::Rc;
+
+    const APP_ID: &str = "org.gtk_rs.ProjectsMenu";
+
+    fn get_dev_directories() -> Vec<PathBuf> {
+        let home = dirs::home_dir().unwrap();
+        let mut directories = Vec::new();
+        directories.push(home.join("owl"));
+        if let Ok(entries) = fs::read_dir(home.join("dev")) {
+            directories.extend(entries.filter_map(|entry| {
+                let entry = entry.ok()?;
+                let path = entry.path();
+                if path.is_dir() {
+                    Some(path)
+                } else {
+                    None
+                }
+            }));
+        }
+        directories
+    }
+
+    fn normalize_name(name: &str) -> String {
+        let with_spaces = name.replace(['-', '_'], " ");
+        let re = Regex::new(r"([a-z])([A-Z])").unwrap();
+        let separated = re.replace_all(&with_spaces, "$1 $2");
+        separated
+            .split_whitespace()
+            .map(|word| {
+                let mut chars = word.chars();
+                match chars.next() {
+                    None => String::new(),
+                    Some(first) => {
+                        first.to_uppercase().collect::<String>()
+                            + &chars.collect::<String>().to_lowercase()
+                    }
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn launch_workspace(workspace_name: &str, directory: &PathBuf) {
+        Command::new("i3-msg")
+            .args(["workspace", workspace_name])
+            .spawn()
+            .expect("Failed to switch workspace");
+        Command::new("i3-msg")
+            .args(["layout", "tabbed"])
+            .spawn()
+            .expect("Failed to set tabbed layout");
+        Command::new("terminator")
+            .arg("--working-directory")
+            .arg(directory)
+            .spawn()
+            .expect("Failed to launch terminal");
+        Command::new("cursor")
+            .arg(directory)
+            .spawn()
+            .expect("Failed to launch editor");
+        Command::new("chromium")
+            .spawn()
+            .expect("Failed to launch browser");
+    }
+
+    fn launch_remote_workspace(workspace_name: &str, host: &str, remote_path: &str) {
+        Command::new("i3-msg")
+            .args(["workspace", workspace_name])
+            .spawn()
+            .expect("Failed to switch workspace");
+        Command::new("i3-msg")
+            .args(["layout", "tabbed"])
+            .spawn()
+            .expect("Failed to set tabbed layout");
+        Command::new("terminator")
+            .args(["-e", &format!("ssh {}", host)])
+            .spawn()
+            .expect("Failed to launch remote terminal");
+        Command::new("cursor")
+            .args(["--remote", &format!("ssh-remote+{}", host), remote_path])
+            .spawn()
+            .expect("Failed to launch remote editor");
+        Command::new("chromium")
+            .spawn()
+            .expect("Failed to launch browser");
+    }
+
+    fn get_remote_dev_directories(host: &str) -> Vec<String> {
+        let output = Command::new("ssh")
+            .args([host, "ls -1 -d ~/dev/*/ 2>/dev/null || true"])
+            .output();
+
+        println!("output: {:?}", output);
+        match output {
+            Ok(o) => {
+                let stdout = String::from_utf8_lossy(&o.stdout);
+                stdout
+                    .lines()
+                    .map(|line| line.trim().trim_end_matches('/').to_string())
+                    .filter(|line| !line.is_empty())
+                    .collect()
+            }
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn build_ui(app: &Application) {
+        let window = ApplicationWindow::builder()
+            .application(app)
+            .title("Project Launcher") // Changed title
+            .default_width(400)
+            .default_height(600)
+            .decorated(true)
+            .resizable(true)
+            .modal(true)
+            .build();
+        let vbox = gtk::Box::new(gtk::Orientation::Vertical, 5);
+        let controls = gtk::Box::new(gtk::Orientation::Horizontal, 5);
+        let btn_local = gtk::Button::with_label("Local");
+        let btn_remote = gtk::Button::with_label("Remote (ada)");
+        let btn_mrwood = gtk::Button::with_label("Remote (mrwood)");
+        let search_entry = Entry::new();
+        let list_box = ListBox::new();
+        list_box.set_vexpand(true);
+        list_box.set_selection_mode(gtk::SelectionMode::Single);
+        list_box.set_activate_on_single_click(true);
+        let scrolled_window = ScrolledWindow::builder()
+            .hscrollbar_policy(gtk::PolicyType::Never)
+            .vscrollbar_policy(gtk::PolicyType::Automatic)
+            .vexpand(true)
+            .child(&list_box)
+            .build();
+        controls.append(&btn_local);
+        controls.append(&btn_remote);
+        controls.append(&btn_mrwood);
+        vbox.append(&controls);
+        vbox.append(&search_entry);
+        vbox.append(&scrolled_window);
+        window.set_child(Some(&vbox));
+        let directories = get_dev_directories();
+        for dir in &directories {
+            let name = dir.file_name().unwrap().to_str().unwrap();
+            let normalized = normalize_name(name);
+            let label = gtk::Label::new(Some(&normalized));
+            label.set_xalign(0.0);
+            label.set_margin_start(5);
+            label.set_margin_end(5);
+            let row = gtk::ListBoxRow::new();
+            row.set_child(Some(&label));
+            list_box.append(&row);
+        }
+        let directories_rc = Rc::new(directories);
+        let current_remote: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+        let remote_cache: Rc<RefCell<HashMap<String, Vec<String>>>> =
+            Rc::new(RefCell::new(HashMap::new()));
+        let list_box_weak_for_buttons = list_box.downgrade();
+        let search_entry_weak_for_buttons = search_entry.downgrade();
+        let directories_rc_for_buttons = directories_rc.clone();
+        let current_remote_for_local = current_remote.clone();
+        btn_local.connect_clicked(move |_| {
+            *current_remote_for_local.borrow_mut() = None;
+            if let (Some(list_box), Some(search_entry)) = (
+                list_box_weak_for_buttons.upgrade(),
+                search_entry_weak_for_buttons.upgrade(),
+            ) {
+                while let Some(row) = list_box.first_child() {
+                    list_box.remove(&row);
+                }
+                let matcher = SkimMatcherV2::default();
+                let query = search_entry.text();
+                let mut matches: Vec<_> = directories_rc_for_buttons
+                    .iter()
+                    .filter_map(|dir| {
+                        let name = dir.file_name().unwrap().to_str().unwrap();
+                        matcher
+                            .fuzzy_match(name, &query)
+                            .map(|score| (score, name.to_string(), dir.clone()))
+                    })
+                    .collect();
+                matches.sort_by(|a, b| b.0.cmp(&a.0));
+                for (_, name, _dir) in matches {
+                    let normalized = normalize_name(&name);
+                    let label = gtk::Label::new(Some(&normalized));
+                    label.set_xalign(0.0);
+                    label.set_margin_start(5);
+                    label.set_margin_end(5);
+                    let row = gtk::ListBoxRow::new();
+                    row.set_child(Some(&label));
+                    list_box.append(&row);
+                }
+            }
+        });
+        let list_box_weak_for_buttons = list_box.downgrade();
+        let search_entry_weak_for_buttons = search_entry.downgrade();
+        let current_remote_for_ada = current_remote.clone();
+        let remote_cache_for_ada = remote_cache.clone();
+        btn_remote.connect_clicked(move |_| {
+            let host = "ada".to_string();
+            *current_remote_for_ada.borrow_mut() = Some(host.clone());
+            if !remote_cache_for_ada.borrow().contains_key(&host) {
+                let fetched = get_remote_dev_directories(&host);
+                remote_cache_for_ada
+                    .borrow_mut()
+                    .insert(host.clone(), fetched);
+            }
+            if let (Some(list_box), Some(search_entry)) = (
+                list_box_weak_for_buttons.upgrade(),
+                search_entry_weak_for_buttons.upgrade(),
+            ) {
+                while let Some(row) = list_box.first_child() {
+                    list_box.remove(&row);
+                }
+                let matcher = SkimMatcherV2::default();
+                let query = search_entry.text();
+                if let Some(remote_dirs) = remote_cache_for_ada.borrow().get(&host) {
+                    let mut matches: Vec<_> = remote_dirs
+                        .iter()
+                        .filter_map(|path| {
+                            let name = path
+                                .trim_end_matches('/')
+                                .rsplit('/')
+                                .next()
+                                .unwrap_or(path);
+                            matcher
+                                .fuzzy_match(name, &query)
+                                .map(|score| (score, name.to_string(), path.to_string()))
+                        })
+                        .collect();
+                    matches.sort_by(|a, b| b.0.cmp(&a.0));
+                    for (_, name, _path) in matches {
+                        let normalized = normalize_name(&name);
+                        let label = gtk::Label::new(Some(&normalized));
+                        label.set_xalign(0.0);
+                        label.set_margin_start(5);
+                        label.set_margin_end(5);
+                        let row = gtk::ListBoxRow::new();
+                        row.set_child(Some(&label));
+                        list_box.append(&row);
+                    }
+                }
+            }
+        });
+        let list_box_weak_for_buttons = list_box.downgrade();
+        let search_entry_weak_for_buttons = search_entry.downgrade();
+        let current_remote_for_mrwood = current_remote.clone();
+        let remote_cache_for_mrwood = remote_cache.clone();
+        btn_mrwood.connect_clicked(move |_| {
+            let host = "mrwood".to_string();
+            *current_remote_for_mrwood.borrow_mut() = Some(host.clone());
+            if !remote_cache_for_mrwood.borrow().contains_key(&host) {
+                let fetched = get_remote_dev_directories(&host);
+                remote_cache_for_mrwood
+                    .borrow_mut()
+                    .insert(host.clone(), fetched);
+            }
+            if let (Some(list_box), Some(search_entry)) = (
+                list_box_weak_for_buttons.upgrade(),
+                search_entry_weak_for_buttons.upgrade(),
+            ) {
+                while let Some(row) = list_box.first_child() {
+                    list_box.remove(&row);
+                }
+                let matcher = SkimMatcherV2::default();
+                let query = search_entry.text();
+                if let Some(remote_dirs) = remote_cache_for_mrwood.borrow().get(&host) {
+                    let mut matches: Vec<_> = remote_dirs
+                        .iter()
+                        .filter_map(|path| {
+                            let name = path
+                                .trim_end_matches('/')
+                                .rsplit('/')
+                                .next()
+                                .unwrap_or(path);
+                            matcher
+                                .fuzzy_match(name, &query)
+                                .map(|score| (score, name.to_string(), path.to_string()))
+                        })
+                        .collect();
+                    matches.sort_by(|a, b| b.0.cmp(&a.0));
+                    for (_, name, _path) in matches {
+                        let normalized = normalize_name(&name);
+                        let label = gtk::Label::new(Some(&normalized));
+                        label.set_xalign(0.0);
+                        label.set_margin_start(5);
+                        label.set_margin_end(5);
+                        let row = gtk::ListBoxRow::new();
+                        row.set_child(Some(&label));
+                        list_box.append(&row);
+                    }
+                }
+            }
+        });
+        let list_box_weak = list_box.downgrade();
+        search_entry.connect_activate(move |_entry| {
+            let list_box = list_box_weak.upgrade().unwrap();
+            if let Some(first_row) = list_box.first_child() {
+                let row_count = list_box.observe_children().n_items();
+                if row_count == 1 {
+                    list_box.emit_by_name::<()>(
+                        "row-activated",
+                        &[&first_row.downcast_ref::<gtk::ListBoxRow>().unwrap()],
+                    );
+                } else if row_count > 1 {
+                    list_box.select_row(Some(first_row.downcast_ref::<gtk::ListBoxRow>().unwrap()));
+                    list_box.grab_focus();
+                }
+            }
+        });
+        let list_box_weak = list_box.downgrade();
+        let directories_rc_for_search = directories_rc.clone();
+        let current_remote_for_search = current_remote.clone();
+        let remote_cache_for_search = remote_cache.clone();
+        search_entry.connect_changed(move |entry| {
+            let list_box = list_box_weak.upgrade().unwrap();
+            let matcher = SkimMatcherV2::default();
+            let query = entry.text();
+            while let Some(row) = list_box.first_child() {
+                list_box.remove(&row);
+            }
+            if let Some(host) = current_remote_for_search.borrow().clone() {
+                if !remote_cache_for_search.borrow().contains_key(&host) {
+                    let fetched = get_remote_dev_directories(&host);
+                    remote_cache_for_search
+                        .borrow_mut()
+                        .insert(host.clone(), fetched);
+                }
+                if let Some(remote_dirs) = remote_cache_for_search.borrow().get(&host) {
+                    let mut matches: Vec<_> = remote_dirs
+                        .iter()
+                        .filter_map(|path| {
+                            let name = path
+                                .trim_end_matches('/')
+                                .rsplit('/')
+                                .next()
+                                .unwrap_or(path);
+                            matcher
+                                .fuzzy_match(name, &query)
+                                .map(|score| (score, name.to_string(), path.to_string()))
+                        })
+                        .collect();
+                    matches.sort_by(|a, b| b.0.cmp(&a.0));
+                    for (_, name, _path) in matches {
+                        let normalized = normalize_name(&name);
+                        let label = gtk::Label::new(Some(&normalized));
+                        label.set_xalign(0.0);
+                        label.set_margin_start(5);
+                        label.set_margin_end(5);
+                        let row = gtk::ListBoxRow::new();
+                        row.set_child(Some(&label));
+                        list_box.append(&row);
+                    }
+                }
+            } else {
+                let mut matches: Vec<_> = directories_rc_for_search
+                    .iter()
+                    .filter_map(|dir| {
+                        let name = dir.file_name().unwrap().to_str().unwrap();
+                        matcher
+                            .fuzzy_match(name, &query)
+                            .map(|score| (score, name.to_string(), dir.clone()))
+                    })
+                    .collect();
+                matches.sort_by(|a, b| b.0.cmp(&a.0));
+                for (_, name, _dir) in matches {
+                    let normalized = normalize_name(&name);
+                    let label = gtk::Label::new(Some(&normalized));
+                    label.set_xalign(0.0);
+                    label.set_margin_start(5);
+                    label.set_margin_end(5);
+                    let row = gtk::ListBoxRow::new();
+                    row.set_child(Some(&label));
+                    list_box.append(&row);
+                }
+            }
+        });
+        let window_weak = window.downgrade();
+        let directories_rc_for_activate = directories_rc.clone();
+        let current_remote_for_activate = current_remote.clone();
+        let remote_cache_for_activate = remote_cache.clone();
+        list_box.connect_row_activated(move |_list_box, row| {
+            let label = row.child().unwrap().downcast::<gtk::Label>().unwrap();
+            let selected_name = label.text();
+            if let Some(host) = current_remote_for_activate.borrow().clone() {
+                if let Some(remote_dirs) = remote_cache_for_activate.borrow().get(&host) {
+                    if let Some(remote_path) = remote_dirs.iter().find_map(|path| {
+                        let name = path
+                            .trim_end_matches('/')
+                            .rsplit('/')
+                            .next()
+                            .unwrap_or(path);
+                        if normalize_name(name) == selected_name.as_str() {
+                            Some(path.clone())
+                        } else {
+                            None
+                        }
+                    }) {
+                        launch_remote_workspace(&selected_name, &host, &remote_path);
+                    }
+                }
+            } else {
+                if let Some(selected_dir) = directories_rc_for_activate.iter().find(|dir| {
+                    normalize_name(dir.file_name().unwrap().to_str().unwrap())
+                        == selected_name.as_str()
+                }) {
+                    launch_workspace(&selected_name, selected_dir);
+                }
+            }
+            if let Some(window) = window_weak.upgrade() {
+                window.close();
+            }
+        });
+        search_entry.grab_focus();
+        window.present();
+    }
+
+    pub fn run_app() -> glib::ExitCode {
+        let app = Application::builder().application_id(APP_ID).build();
+        app.connect_activate(build_ui);
+        let no_args: [&str; 0] = [];
+        app.run_with_args(&no_args)
+    }
+}

--- a/src/omni_menu/scripts_menu.rs
+++ b/src/omni_menu/scripts_menu.rs
@@ -1,0 +1,124 @@
+pub mod scripts_menu {
+    use gtk::prelude::*;
+    use gtk::{
+        glib, Application, ApplicationWindow, Box as GtkBox, Entry, Label, ListBox,
+        Orientation, ScrolledWindow,
+    };
+    use std::process::Command;
+    use crate::utils::{populate_list, filter_list};
+
+    const APP_ID: &str = "org.gtk_rs.ScriptsMenu";
+
+    fn build_ui(app: &Application) {
+        let window = ApplicationWindow::builder()
+            .application(app)
+            .title("Scripts")
+            .default_width(500)
+            .default_height(600)
+            .decorated(true)
+            .resizable(false)
+            .modal(true)
+            .build();
+
+        let vbox = GtkBox::new(Orientation::Vertical, 5);
+        vbox.set_margin_top(10);
+        vbox.set_margin_bottom(10);
+        vbox.set_margin_start(10);
+        vbox.set_margin_end(10);
+
+        // Search entry
+        let search_entry = Entry::new();
+        search_entry.set_placeholder_text(Some("Type to filter scripts..."));
+        vbox.append(&search_entry);
+
+        // Scrolled window
+        let scrolled_window = ScrolledWindow::builder()
+            .hscrollbar_policy(gtk::PolicyType::Never)
+            .vscrollbar_policy(gtk::PolicyType::Automatic)
+            .vexpand(true)
+            .build();
+
+        let list_box = ListBox::new();
+        list_box.set_selection_mode(gtk::SelectionMode::Single);
+        list_box.set_activate_on_single_click(true);
+        scrolled_window.set_child(Some(&list_box));
+
+        vbox.append(&scrolled_window);
+        window.set_child(Some(&vbox));
+
+        // Get scripts and populate
+        let scripts = get_owl_scripts();
+        populate_list(&list_box, &scripts);
+
+        // Handle search
+        let list_box_weak = list_box.downgrade();
+        let scripts_clone = scripts.clone();
+        search_entry.connect_changed(move |entry| {
+            if let Some(list_box) = list_box_weak.upgrade() {
+                let query = entry.text().to_string().to_lowercase();
+                filter_list(&list_box, &scripts_clone, &query);
+            }
+        });
+
+        // Handle activation
+        let window_weak = window.downgrade();
+        list_box.connect_row_activated(move |_, row| {
+            if let Some(label) = row.child().and_then(|w| w.downcast::<Label>().ok()) {
+                let script_name = label.text().to_string();
+                // Run the script
+                let home = std::env::var("HOME").unwrap_or_default();
+                let script_path = format!("{}/owl/common/scripts/{}", home, script_name);
+                Command::new(&script_path).spawn().ok();
+
+                if let Some(window) = window_weak.upgrade() {
+                    window.close();
+                }
+            }
+        });
+
+        // Handle Escape key
+        let key_controller = gtk::EventControllerKey::new();
+        let window_weak_key = window.downgrade();
+        key_controller.connect_key_pressed(move |_, key, _, _| {
+            if key == gtk::gdk::Key::Escape {
+                if let Some(window) = window_weak_key.upgrade() {
+                    window.close();
+                }
+                return glib::Propagation::Stop;
+            }
+            glib::Propagation::Proceed
+        });
+        window.add_controller(key_controller);
+
+        search_entry.grab_focus();
+        window.present();
+    }
+
+    fn get_owl_scripts() -> Vec<String> {
+        let home = std::env::var("HOME").unwrap_or_default();
+        let scripts_dir = format!("{}/owl/common/scripts", home);
+
+        match std::fs::read_dir(&scripts_dir) {
+            Ok(entries) => {
+                let mut scripts: Vec<String> = entries
+                    .filter_map(|entry| entry.ok())
+                    .filter_map(|entry| {
+                        let file_name = entry.file_name();
+                        file_name.to_str().map(|s| s.to_string())
+                    })
+                    .collect();
+                scripts.sort();
+                scripts
+            }
+            Err(_) => Vec::new(),
+        }
+    }
+
+    pub fn run_app() -> glib::ExitCode {
+        let app = Application::builder().application_id(APP_ID).build();
+        app.connect_activate(build_ui);
+        let no_args: [&str; 0] = [];
+        app.run_with_args(&no_args)
+    }
+}
+

--- a/src/omni_menu/scripts_menu.rs
+++ b/src/omni_menu/scripts_menu.rs
@@ -65,9 +65,9 @@ pub mod scripts_menu {
         list_box.connect_row_activated(move |_, row| {
             if let Some(label) = row.child().and_then(|w| w.downcast::<Label>().ok()) {
                 let script_name = label.text().to_string();
-                // Run the script
+                // Run the script - follow symlink to actual script
                 let home = std::env::var("HOME").unwrap_or_default();
-                let script_path = format!("{}/owl/common/scripts/{}", home, script_name);
+                let script_path = format!("{}/.config/owl/menu-scripts/{}", home, script_name);
                 Command::new(&script_path).spawn().ok();
 
                 if let Some(window) = window_weak.upgrade() {
@@ -96,7 +96,7 @@ pub mod scripts_menu {
 
     fn get_owl_scripts() -> Vec<String> {
         let home = std::env::var("HOME").unwrap_or_default();
-        let scripts_dir = format!("{}/owl/common/scripts", home);
+        let scripts_dir = format!("{}/.config/owl/menu-scripts", home);
 
         match std::fs::read_dir(&scripts_dir) {
             Ok(entries) => {

--- a/src/omni_menu/search_menu.rs
+++ b/src/omni_menu/search_menu.rs
@@ -1,0 +1,143 @@
+pub mod search_menu {
+    use gtk::prelude::*;
+    use gtk::{
+        glib, Application, ApplicationWindow, Box as GtkBox, Entry, Justification, Label,
+        Orientation,
+    };
+    use std::process::Command;
+
+    const APP_ID: &str = "org.gtk_rs.SearchMenu";
+
+    struct SearchEngine {
+        trigger: &'static str,
+        name: &'static str,
+        url_template: &'static str,
+    }
+
+    static SEARCH_ENGINES: &[SearchEngine] = &[
+        SearchEngine {
+            trigger: "!g",
+            name: "Google",
+            url_template: "https://www.google.com/search?q={}",
+        },
+        SearchEngine {
+            trigger: "!c",
+            name: "ChatGPT",
+            url_template: "https://chat.openai.com/?q={}",
+        },
+        SearchEngine {
+            trigger: "!n",
+            name: "Notes",
+            url_template: "https://tylertracy.com/notes?search={}",
+        },
+    ];
+
+    static DEFAULT_SEARCH_ENGINE: &SearchEngine = &SEARCH_ENGINES[0];
+
+    fn launch_search(url_template: &str, query: &str) {
+        let encoded_query = glib::uri_escape_string(query, None::<&str>, true);
+        let search_url = url_template.replace("{}", &encoded_query);
+        Command::new("chromium")
+            .arg(&search_url)
+            .spawn()
+            .expect("Failed to launch browser");
+    }
+
+    fn build_ui(app: &Application) {
+        println!("Building UI");
+
+        let window = ApplicationWindow::builder()
+            .application(app)
+            .title("Omni Search")
+            .default_width(450)
+            .default_height(160)
+            .decorated(true)
+            .resizable(false)
+            .modal(true)
+            .build();
+
+        let vbox = GtkBox::new(Orientation::Vertical, 5);
+        vbox.set_margin_top(10);
+        vbox.set_margin_bottom(10);
+        vbox.set_margin_start(10);
+        vbox.set_margin_end(10);
+
+        let search_entry = Entry::new();
+        vbox.append(&search_entry);
+
+        let mut engine_display_text = String::from("Available Engines:\n");
+        for engine in SEARCH_ENGINES.iter() {
+            engine_display_text.push_str(&format!("  {}  -  {}\n", engine.trigger, engine.name));
+        }
+        if engine_display_text.ends_with('\n') {
+            engine_display_text.pop();
+        }
+
+        let engines_label = Label::new(Some(&engine_display_text));
+        engines_label.set_halign(gtk::Align::Start);
+        engines_label.set_xalign(0.0);
+        engines_label.set_justify(Justification::Left);
+        vbox.append(&engines_label);
+
+        window.set_child(Some(&vbox));
+
+        let window_weak = window.downgrade();
+        search_entry.connect_activate(move |entry| {
+            let original_text = entry.text();
+            if original_text.is_empty() {
+                return;
+            }
+
+            let mut query_to_search = original_text.to_string();
+            let mut selected_engine = DEFAULT_SEARCH_ENGINE;
+            let mut trigger_found = false;
+
+            for engine in SEARCH_ENGINES.iter() {
+                if let Some(_index) = query_to_search.find(engine.trigger) {
+                    selected_engine = engine;
+                    query_to_search = query_to_search.replacen(engine.trigger, "", 1);
+                    query_to_search = query_to_search.trim().to_string();
+                    trigger_found = true;
+                    break;
+                }
+            }
+
+            if !query_to_search.is_empty() {
+                println!(
+                    "Searching with: {} for: '{}'",
+                    selected_engine.name, query_to_search
+                );
+                launch_search(selected_engine.url_template, &query_to_search);
+                if let Some(window) = window_weak.upgrade() {
+                    window.close();
+                }
+            } else if trigger_found && query_to_search.is_empty() {
+                println!(
+                    "Input was a trigger '{}' resulting in an empty query.",
+                    original_text
+                );
+                entry.set_text("");
+                entry.set_placeholder_text(Some(&format!(
+                    "Enter query for {}",
+                    selected_engine.name
+                )));
+            } else if !trigger_found && original_text.is_empty() {
+                println!("Original text was empty or became empty with no trigger.");
+            }
+        });
+
+        search_entry.grab_focus();
+        window.present();
+    }
+
+    pub fn run_app() -> glib::ExitCode {
+        println!("Running app");
+        let app = Application::builder().application_id(APP_ID).build();
+        println!("App built");
+        app.connect_activate(build_ui);
+        println!("App activated");
+        let no_args: [&str; 0] = [];
+        app.run_with_args(&no_args);
+        glib::ExitCode::SUCCESS
+    }
+}

--- a/src/omni_menu/switch_bench_menu.rs
+++ b/src/omni_menu/switch_bench_menu.rs
@@ -1,0 +1,126 @@
+pub mod switch_bench_menu {
+    use gtk::prelude::*;
+    use gtk::{
+        glib, Application, ApplicationWindow, Box as GtkBox, Entry, Label, ListBox,
+        Orientation, ScrolledWindow,
+    };
+    use std::process::Command;
+    use crate::utils::{populate_list, filter_list};
+
+    const APP_ID: &str = "org.gtk_rs.SwitchBenchMenu";
+
+    fn build_ui(app: &Application) {
+        let window = ApplicationWindow::builder()
+            .application(app)
+            .title("Switch Bench")
+            .default_width(500)
+            .default_height(600)
+            .decorated(true)
+            .resizable(false)
+            .modal(true)
+            .build();
+
+        let vbox = GtkBox::new(Orientation::Vertical, 5);
+        vbox.set_margin_top(10);
+        vbox.set_margin_bottom(10);
+        vbox.set_margin_start(10);
+        vbox.set_margin_end(10);
+
+        // Search entry
+        let search_entry = Entry::new();
+        search_entry.set_placeholder_text(Some("Type to filter benches..."));
+        vbox.append(&search_entry);
+
+        // Scrolled window
+        let scrolled_window = ScrolledWindow::builder()
+            .hscrollbar_policy(gtk::PolicyType::Never)
+            .vscrollbar_policy(gtk::PolicyType::Automatic)
+            .vexpand(true)
+            .build();
+
+        let list_box = ListBox::new();
+        list_box.set_selection_mode(gtk::SelectionMode::Single);
+        list_box.set_activate_on_single_click(true);
+        scrolled_window.set_child(Some(&list_box));
+
+        vbox.append(&scrolled_window);
+        window.set_child(Some(&vbox));
+
+        // Get benches and populate
+        let benches = get_yard_benches();
+        populate_list(&list_box, &benches);
+
+        // Handle search
+        let list_box_weak = list_box.downgrade();
+        let benches_clone = benches.clone();
+        search_entry.connect_changed(move |entry| {
+            if let Some(list_box) = list_box_weak.upgrade() {
+                let query = entry.text().to_string().to_lowercase();
+                filter_list(&list_box, &benches_clone, &query);
+            }
+        });
+
+        // Handle activation
+        let window_weak = window.downgrade();
+        list_box.connect_row_activated(move |_, row| {
+            if let Some(label) = row.child().and_then(|w| w.downcast::<Label>().ok()) {
+                let bench_name = label.text().to_string();
+                // Call yard to focus the bench
+                Command::new("yard")
+                    .args(["bench", "focus", &bench_name])
+                    .spawn()
+                    .ok();
+
+                if let Some(window) = window_weak.upgrade() {
+                    window.close();
+                }
+            }
+        });
+
+        // Handle Escape key
+        let key_controller = gtk::EventControllerKey::new();
+        let window_weak_key = window.downgrade();
+        key_controller.connect_key_pressed(move |_, key, _, _| {
+            if key == gtk::gdk::Key::Escape {
+                if let Some(window) = window_weak_key.upgrade() {
+                    window.close();
+                }
+                return glib::Propagation::Stop;
+            }
+            glib::Propagation::Proceed
+        });
+        window.add_controller(key_controller);
+
+        search_entry.grab_focus();
+        window.present();
+    }
+
+    fn get_yard_benches() -> Vec<String> {
+        println!("Running: yard bench list");
+        let output = Command::new("yard").args(["bench", "list"]).output();
+
+        match output {
+            Ok(o) => {
+                let stdout = String::from_utf8_lossy(&o.stdout);
+                stdout
+                    .lines()
+                    .map(|line| line.trim())
+                    .filter(|line| !line.is_empty())
+                    .map(|s| s.to_string())
+                    .collect()
+            }
+            Err(e) => {
+                println!("Error running yard: {}", e);
+                Vec::new()
+            }
+        }
+    }
+
+    pub fn run_app() -> glib::ExitCode {
+        let app = Application::builder().application_id(APP_ID).build();
+        app.connect_activate(build_ui);
+        let no_args: [&str; 0] = [];
+        app.run_with_args(&no_args)
+    }
+}
+

--- a/src/omni_menu/utils.rs
+++ b/src/omni_menu/utils.rs
@@ -1,0 +1,28 @@
+use gtk::prelude::*;
+use gtk::{Label, ListBox, ListBoxRow};
+
+pub fn populate_list(list_box: &ListBox, items: &[String]) {
+    for item in items {
+        let row = ListBoxRow::new();
+        let label = Label::new(Some(item));
+        label.set_xalign(0.0);
+        label.set_margin_start(10);
+        label.set_margin_end(10);
+        label.set_margin_top(8);
+        label.set_margin_bottom(8);
+        row.set_child(Some(&label));
+        list_box.append(&row);
+    }
+}
+
+pub fn filter_list(list_box: &ListBox, _items: &[String], query: &str) {
+    let mut index = 0;
+    while let Some(row) = list_box.row_at_index(index) {
+        if let Some(label) = row.child().and_then(|w| w.downcast::<Label>().ok()) {
+            let text = label.text().to_string();
+            let visible = query.is_empty() || text.to_lowercase().contains(query);
+            row.set_visible(visible);
+        }
+        index += 1;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Integrates a new GTK4-based launcher and associated tooling, plus selective menu-script behavior.
> 
> - Add `omni-menu` binary (`src/omni_menu/*`) with submenus: main, search, projects, scripts, launch_tool, switch_bench, desk, emoji
> - Update `Cargo.toml` with second binary and new deps (`gtk4`, `fuzzy-matcher`, `dirs`, `regex`)
> - Wire into setups: `setups/menu/setup.json` links `target/release/omni-menu` to `~/.local/bin/omni-menu`; remove old install script
> - i3 config: change hotkeys to use `omni-menu` (launch_tool, main) and `rofi -show window`
> - Nest `framework-sway`: add `bg-picker.sh` and menu entry; set `only_own_menu_scripts: true`
> - Core CLI: support `only_own_menu_scripts` in `setup.json` and skip linking inherited menu scripts in dependency traversal
> - Sway desk script: adjust display scale (1.5) and keyboard repeat settings; Kitty config adds Shift+Enter mapping
> - Add `CLAUDE.md` with repo guidance and omni-menu architecture
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4e2b9f655f6bc9dd16a7005317d6b8ac7a3a8fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->