### PR TITLE
Fix nest schema: rename 'setups' to 'dependencies'

### DIFF
--- a/nests/dell-xps-desktop/setup.json
+++ b/nests/dell-xps-desktop/setup.json
@@ -21,7 +21,7 @@
       "target": "~/.ssh/config"
     }
   ],
-  "setups": [
+  "dependencies": [
     "git",
     "bash",
     "i3",

--- a/nests/framework-arch/setup.json
+++ b/nests/framework-arch/setup.json
@@ -25,7 +25,7 @@
       "target": "~/.local/bin/f"
     }
   ],
-  "setups": [
+  "dependencies": [
     "git",
     "bun",
     "bash",

--- a/nests/home-pi/setup.json
+++ b/nests/home-pi/setup.json
@@ -9,6 +9,6 @@
       "target": "~/.local/bin/start-eco"
     }
   ],
-  "setups": [],
+  "dependencies": [],
   "rc_scripts": []
 }

--- a/nests/mac/setup.json
+++ b/nests/mac/setup.json
@@ -13,7 +13,7 @@
       "target": "~/.local/bin/daily-note"
     }
   ],
-  "setups": [
+  "dependencies": [
     "git",
     "node",
     "nvim",

--- a/nests/redwood/setup.json
+++ b/nests/redwood/setup.json
@@ -9,7 +9,7 @@
       "target": "~/.local/bin/f"
     }
   ],
-  "setups": [
+  "dependencies": [
     "git",
     "nvim",
     "nvm",
@@ -23,7 +23,6 @@
     "common:fzf.sh",
     "common:base-aliases.sh",
     "common:claude.sh",
-    "local:.shenv",
-    ".secrets"
+    "local:.shenv"
   ]
 }


### PR DESCRIPTION
- Updated all nests to use 'dependencies' field instead of deprecated 'setups'
- Removed invalid .secrets rc_script reference from redwood nest
- All nests now validate correctly with current schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns nest configs with the current schema and removes an invalid reference.
> 
> - Replace `setups` with `dependencies` in `dell-xps-desktop`, `framework-arch`, `home-pi`, `mac`, and `redwood` setup files
> - Remove invalid `.secrets` entry from `redwood` `rc_scripts`
> - All nests now validate against the updated schema
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49f0ba4ab6cda9fb95c76a9bd731796b0144bcbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->